### PR TITLE
set absolute path to stat for OSX

### DIFF
--- a/fabric-completion.bash
+++ b/fabric-completion.bash
@@ -43,7 +43,7 @@ export FAB_COMPLETION_CACHED_TASKS_FILENAME=".fab_tasks~"
 # Set command to get time of last file modification as seconds since Epoch
 case $(uname) in
     Darwin|FreeBSD)
-        __FAB_COMPLETION_MTIME_COMMAND="stat -f '%m'"
+        __FAB_COMPLETION_MTIME_COMMAND="/usr/bin/stat -f '%m'"
         ;;
     *)
         __FAB_COMPLETION_MTIME_COMMAND="stat -c '%Y'"


### PR DESCRIPTION
When installing coreutils on OSX it overrides the default stat command with the GNU command.
The result is that the completion doesn't work.
To fix this issue I set the full path to the system stat command.
